### PR TITLE
Improve text extraction error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,16 +74,15 @@ with col1:
                 with st.spinner("テキストを抽出中..."):
                     try:
                         result = extract_text_from_url(url)
-                        if isinstance(result, str) and result.startswith(
-                            "URLからのテキスト抽出エラー"
-                        ):
+                    except requests.exceptions.RequestException as e:
+                        st.error(str(e))
+                    else:
+                        if isinstance(result, str) and result.startswith("Error:"):
                             st.error(result)
                         else:
                             text_content = result
                             source_info = f"URL: {url}"
                             st.success("テキストの抽出が完了しました")
-                    except requests.exceptions.RequestException as e:
-                        st.error(str(e))
             else:
                 st.error("URLを入力してください")
     
@@ -100,20 +99,15 @@ with col1:
                 with st.spinner("テキストを抽出中..."):
                     try:
                         result = extract_text_from_uploaded_file(uploaded_file, file_type)
-                        if isinstance(result, str) and result.startswith(
-                            (
-                                "PDFからのテキスト抽出エラー",
-                                "DOCXからのテキスト抽出エラー",
-                                "サポートされていないファイル形式",
-                            )
-                        ):
+                    except Exception as e:
+                        st.error(str(e))
+                    else:
+                        if isinstance(result, str) and result.startswith("Error:"):
                             st.error(result)
                         else:
                             text_content = result
                             source_info = f"ファイル: {uploaded_file.name}"
                             st.success("テキストの抽出が完了しました")
-                    except Exception as e:
-                        st.error(str(e))
     
     # 抽出されたテキストの表示
     if text_content:

--- a/qna_generator/data_processor.py
+++ b/qna_generator/data_processor.py
@@ -22,7 +22,7 @@ def extract_text_from_url(url):
     except requests.exceptions.RequestException as e:
         raise requests.exceptions.RequestException(
             f"URLからのテキスト抽出エラー: {e}"
-        )
+        ) from e
 
 def extract_text_from_pdf(file_path):
     text = ""
@@ -32,7 +32,7 @@ def extract_text_from_pdf(file_path):
                 text += page.get_text()
         return text
     except Exception as e:
-        raise RuntimeError(f"PDFからのテキスト抽出エラー: {e}")
+        raise RuntimeError(f"PDFからのテキスト抽出エラー: {e}") from e
 
 def extract_text_from_docx(file_path):
     text = ""
@@ -42,7 +42,7 @@ def extract_text_from_docx(file_path):
             text += para.text + "\n"
         return text
     except Exception as e:
-        raise RuntimeError(f"DOCXからのテキスト抽出エラー: {e}")
+        raise RuntimeError(f"DOCXからのテキスト抽出エラー: {e}") from e
 
 # Streamlitのfile_uploaderでアップロードされたファイルオブジェクトを処理するための関数
 def extract_text_from_uploaded_file(uploaded_file, file_type):
@@ -56,7 +56,7 @@ def extract_text_from_uploaded_file(uploaded_file, file_type):
             doc.close()
             return text
         except Exception as e:
-            raise RuntimeError(f"PDFからのテキスト抽出エラー: {e}")
+            raise RuntimeError(f"PDFからのテキスト抽出エラー: {e}") from e
     elif file_type == "docx":
         try:
             # アップロードされたファイルのバイトデータを直接使用
@@ -66,7 +66,7 @@ def extract_text_from_uploaded_file(uploaded_file, file_type):
                 text += para.text + "\n"
             return text
         except Exception as e:
-            raise RuntimeError(f"DOCXからのテキスト抽出エラー: {e}")
+            raise RuntimeError(f"DOCXからのテキスト抽出エラー: {e}") from e
     else:
         raise ValueError("サポートされていないファイル形式です。")
 


### PR DESCRIPTION
## Summary
- verify extracted text results for error prefixes and show `st.error` instead of success
- raise and chain exceptions in data processor utilities for URL, PDF, and DOCX text extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688eb85fe8748333aa376a3c1d831d1f