### PR TITLE
Handle extraction errors in text processing

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,11 @@ from qna_generator.data_exporter import (
     export_for_finetuning,
 )
 
+
+def _has_error_prefix(value: str) -> bool:
+    """Return True if the text looks like an error message."""
+    return isinstance(value, str) and value.startswith(("Error", "エラー"))
+
 # ページ設定
 st.set_page_config(
     page_title="Q&A自動生成システム",
@@ -77,7 +82,7 @@ with col1:
                     except requests.exceptions.RequestException as e:
                         st.error(str(e))
                     else:
-                        if isinstance(result, str) and result.startswith("Error:"):
+                        if _has_error_prefix(result):
                             st.error(result)
                         else:
                             text_content = result
@@ -102,7 +107,7 @@ with col1:
                     except Exception as e:
                         st.error(str(e))
                     else:
-                        if isinstance(result, str) and result.startswith("Error:"):
+                        if _has_error_prefix(result):
                             st.error(result)
                         else:
                             text_content = result

--- a/qna_generator/data_processor.py
+++ b/qna_generator/data_processor.py
@@ -6,6 +6,11 @@ from docx import Document
 import io
 
 def extract_text_from_url(url):
+    """Fetch and clean text content from the given URL.
+
+    Raises:
+        requests.exceptions.RequestException: ネットワーク関連のエラーが発生した場合。
+    """
     try:
         response = requests.get(url)
         response.raise_for_status()  # HTTPエラーをチェック
@@ -17,7 +22,7 @@ def extract_text_from_url(url):
         # 複数の空白や改行を一つにまとめる
         lines = (line.strip() for line in text.splitlines())
         chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
-        text = '\n'.join(chunk for chunk in chunks if chunk)
+        text = "\n".join(chunk for chunk in chunks if chunk)
         return text
     except requests.exceptions.RequestException as e:
         raise requests.exceptions.RequestException(
@@ -25,6 +30,7 @@ def extract_text_from_url(url):
         ) from e
 
 def extract_text_from_pdf(file_path):
+    """Extract text from a PDF file."""
     text = ""
     try:
         with fitz.open(file_path) as doc:
@@ -35,6 +41,7 @@ def extract_text_from_pdf(file_path):
         raise RuntimeError(f"PDFからのテキスト抽出エラー: {e}") from e
 
 def extract_text_from_docx(file_path):
+    """Extract text from a DOCX file."""
     text = ""
     try:
         doc = Document(file_path)
@@ -46,6 +53,7 @@ def extract_text_from_docx(file_path):
 
 # Streamlitのfile_uploaderでアップロードされたファイルオブジェクトを処理するための関数
 def extract_text_from_uploaded_file(uploaded_file, file_type):
+    """Handle text extraction for Streamlit-uploaded files."""
     if file_type == "pdf":
         try:
             # アップロードされたファイルのバイトデータを直接使用


### PR DESCRIPTION
## Summary
- detect error-prefixed extraction results before populating text
- document and enforce exception-based errors in data processor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ebf5a0c7883338ab92ae8269d2caa