### PR TITLE
Improve QA parsing resilience

### DIFF
--- a/qna_generator/ai_qa_generator.py
+++ b/qna_generator/ai_qa_generator.py
@@ -49,15 +49,16 @@ class AIQAGenerator:
         qa_list = []
         lines = qa_text.split("\n")
         current_qa = {}
-        key_pattern = re.compile(r"^(質問|回答|引用元)\s*\d*")
+        key_pattern = re.compile(r"^(質問|回答|引用元)\s*\d*$")
         for line in lines:
             line = line.strip()
             if not line:
                 continue
-            if ":" not in line:
+            segments = [seg.strip() for seg in line.split(":", 1)]
+            if len(segments) != 2:
                 logger.warning("Skipping malformed line: %s", line)
                 continue
-            key_part, value_part = [seg.strip() for seg in line.split(":", 1)]
+            key_part, value_part = segments
             if not key_part or not value_part:
                 logger.warning("Skipping malformed line: %s", line)
                 continue


### PR DESCRIPTION
## Summary
- Split QA lines on `:` and strip whitespace for robust parsing
- Warn and skip malformed lines or incomplete QA pairs
- Anchor key regex to handle spacing or numbering around 質問/回答/引用元

## Testing
- `python -m py_compile qna_generator/*.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ec3fbd8c88333989a72e0b9ce431f