### PR TITLE
feat: make question generation count configurable

### DIFF
--- a/qna_generator/ai_qa_generator.py
+++ b/qna_generator/ai_qa_generator.py
@@ -27,8 +27,21 @@ class AIQAGenerator:
         except Exception as e:
             return [f"カテゴリ生成エラー: {e}"]
 
-    def generate_qa_for_category(self, text, category, temperature=0.0):
-        prompt = f"""以下のテキストとカテゴリに基づいて、ユーザーが最も知りたいであろう質問とそれに対する回答を5つ生成してください。回答は必ず提供されたテキストの内容のみから生成し、引用元を明確にしてください。引用元はテキストの該当箇所を特定できる形で示してください。\n\nカテゴリ: {category}\nテキスト:\n{text}\n\n形式:\n質問1: [質問内容]\n回答1: [回答内容]\n引用元1: [引用元のテキスト]\n\n質問2: [質問内容]\n回答2: [回答内容]\n引用元2: [引用元のテキスト]\n..."""
+    def generate_qa_for_category(self, text, category, temperature=0.0, num_questions=5):
+        format_lines = []
+        for i in range(1, num_questions + 1):
+            format_lines.extend([
+                f"質問{i}: [質問内容]",
+                f"回答{i}: [回答内容]",
+                f"引用元{i}: [引用元のテキスト]",
+                "",
+            ])
+        format_example = "\n".join(format_lines).strip()
+        prompt = (
+            f"以下のテキストとカテゴリに基づいて、ユーザーが最も知りたいであろう質問とそれに対する回答を{num_questions}つ生成してください。"
+            "回答は必ず提供されたテキストの内容のみから生成し、引用元を明確にしてください。引用元はテキストの該当箇所を特定できる形で示してください。"
+            f"\n\nカテゴリ: {category}\nテキスト:\n{text}\n\n形式:\n{format_example}"
+        )
         try:
             response = self.client.chat.completions.create(
                 model="gpt-4o-mini",  # GPT-4.1 nanoの代わりにgpt-4o-miniを使用


### PR DESCRIPTION
## Summary
- add `num_questions` parameter to AIQAGenerator.generate_qa_for_category
- build prompt and format section based on requested number of questions
- confirm QA parser handles arbitrary numbers of pairs

## Testing
- `python -m py_compile qna_generator/ai_qa_generator.py`
- `python -m py_compile app.py`
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('ai_qa_generator', 'qna_generator/ai_qa_generator.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
sample_lines=[]
for i in range(1,8):
    sample_lines.append(f"質問{i}: Q{i}")
    sample_lines.append(f"回答{i}: A{i}")
    sample_lines.append(f"引用元{i}: S{i}")
    sample_lines.append("")
text='\n'.join(sample_lines)
print(len(mod.AIQAGenerator._parse_qa_pairs(None, text)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688ecd07705883339fa2b07979173282