### PR TITLE
feat: allow custom category count

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,15 @@ with st.sidebar:
         help="OpenAI APIキーを入力してください"
     )
     st.session_state.api_key = api_key
-    
+
+    num_categories = st.number_input(
+        "生成するカテゴリ数",
+        min_value=1,
+        value=3,
+        step=1,
+        help="生成されるカテゴリの数",
+    )
+
     # 生成する質問数とブロックサイズ
     question_mode = st.radio(
         "質問数の指定方法",
@@ -147,7 +155,7 @@ with col2:
         
         if st.button("カテゴリとQ&Aを生成"):
             with st.spinner("カテゴリを生成中..."):
-                categories = generator.generate_categories(text_content, 0.0)
+                categories = generator.generate_categories(text_content, 0.0, num_categories)
             
             if categories and not any("エラー" in str(cat) for cat in categories):
                 st.success(f"カテゴリが生成されました: {', '.join(categories)}")
@@ -155,10 +163,10 @@ with col2:
                 # 各カテゴリでQ&Aを生成
                 if question_mode == "全カテゴリ合計質問数":
                     total_questions = num_questions_input
-                    num_categories = len(categories)
-                    base = total_questions // num_categories
-                    remainder = total_questions % num_categories
-                    per_category_counts = [base + (1 if i < remainder else 0) for i in range(num_categories)]
+                    generated_category_count = len(categories)
+                    base = total_questions // generated_category_count
+                    remainder = total_questions % generated_category_count
+                    per_category_counts = [base + (1 if i < remainder else 0) for i in range(generated_category_count)]
                 else:
                     per_category_counts = [num_questions_input] * len(categories)
 

--- a/qna_generator/ai_qa_generator.py
+++ b/qna_generator/ai_qa_generator.py
@@ -10,8 +10,8 @@ class AIQAGenerator:
     def __init__(self, api_key):
         self.client = OpenAI(api_key=api_key)
 
-    def generate_categories(self, text, temperature=0.0):
-        prompt = f"""以下のテキストから、関連性の高いカテゴリを3つ提案してください。カテゴリは簡潔な名詞で、カンマ区切りで出力してください。\n\nテキスト:\n{text}\n\nカテゴリ:"""
+    def generate_categories(self, text, temperature=0.0, num_categories=3):
+        prompt = f"""以下のテキストから、関連性の高いカテゴリを{num_categories}つ提案してください。カテゴリは簡潔な名詞で、カンマ区切りで出力してください。\n\nテキスト:\n{text}\n\nカテゴリ:"""
         try:
             response = self.client.chat.completions.create(
                 model="gpt-4o-mini",  # GPT-4.1 nanoの代わりにgpt-4o-miniを使用
@@ -23,7 +23,7 @@ class AIQAGenerator:
                 max_tokens=50
             )
             categories = response.choices[0].message.content.strip()
-            return [c.strip() for c in categories.split(",")]
+            return [c.strip() for c in categories.split(",")][:num_categories]
         except Exception as e:
             return [f"カテゴリ生成エラー: {e}"]
 


### PR DESCRIPTION
## Summary
- make category generation accept desired count
- expose category count as a Streamlit option and pass to generator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ed345dd708333a2c7088a6f7a4e92