### PR TITLE
feat: add model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,19 @@ pip install -r requirements.txt
     ```bash
     streamlit run app.py
     ```
-3. A browser window will open. Enter an API key if you didn't set one, then provide a URL or upload a PDF/DOCX file to generate Q&A pairs.
+3. A browser window will open. Enter an API key if you didn't set one, choose an OpenAI model in the sidebar (defaults to `gpt-4o-mini`), then provide a URL or upload a PDF/DOCX file to generate Q&A pairs.
+
+## Model configuration
+
+The "Settings" sidebar includes a **model** selector. The chosen model is used for both category and Q&A generation.
+Supported options include `gpt-4o-mini` and `gpt-4o`.
+
+When using the generator programmatically, pass the model name to `AIQAGenerator`:
+
+```python
+from qna_generator.ai_qa_generator import AIQAGenerator
+generator = AIQAGenerator(api_key="YOUR_API_KEY", model="gpt-4o")
+```
 
 ## Documentation
 

--- a/app.py
+++ b/app.py
@@ -30,6 +30,8 @@ if 'qa_data' not in st.session_state:
     st.session_state.qa_data = []
 if 'api_key' not in st.session_state:
     st.session_state.api_key = ""
+if 'model' not in st.session_state:
+    st.session_state.model = "gpt-4o-mini"
 
 # タイトル
 st.title("🤖 Q&A自動生成システム")
@@ -47,6 +49,14 @@ with st.sidebar:
         help="OpenAI APIキーを入力してください"
     )
     st.session_state.api_key = api_key
+
+    model = st.selectbox(
+        "使用するモデル",
+        ["gpt-4o-mini", "gpt-4o"],
+        index=["gpt-4o-mini", "gpt-4o"].index(st.session_state.model),
+        help="OpenAIのモデルを選択してください",
+    )
+    st.session_state.model = model
 
     num_categories = st.number_input(
         "生成するカテゴリ数",
@@ -152,7 +162,7 @@ with col2:
     st.header("Q&A生成")
     
     if text_content and st.session_state.api_key:
-        generator = AIQAGenerator(st.session_state.api_key)
+        generator = AIQAGenerator(st.session_state.api_key, model=st.session_state.model)
         
         if st.button("カテゴリとQ&Aを生成"):
             with st.spinner("カテゴリを生成中..."):

--- a/qna_generator/ai_qa_generator.py
+++ b/qna_generator/ai_qa_generator.py
@@ -6,15 +6,17 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class AIQAGenerator:
-    def __init__(self, api_key):
+    def __init__(self, api_key, model="gpt-4o-mini"):
         self.client = OpenAI(api_key=api_key)
+        self.model = model
 
     def generate_categories(self, text, temperature=0.0, num_categories=3):
         prompt = f"""以下のテキストから、関連性の高いカテゴリを{num_categories}つ提案してください。カテゴリは簡潔な名詞で、カンマ区切りで出力してください。\n\nテキスト:\n{text}\n\nカテゴリ:"""
         try:
             response = self.client.chat.completions.create(
-                model="gpt-4o-mini",  # GPT-4.1 nanoの代わりにgpt-4o-miniを使用
+                model=self.model,
                 messages=[
                     {"role": "system", "content": "あなたはテキストからカテゴリを抽出するAIアシスタントです。"},
                     {"role": "user", "content": prompt}
@@ -44,7 +46,7 @@ class AIQAGenerator:
         )
         try:
             response = self.client.chat.completions.create(
-                model="gpt-4o-mini",  # GPT-4.1 nanoの代わりにgpt-4o-miniを使用
+                model=self.model,
                 messages=[
                     {"role": "system", "content": "あなたはテキストから質問と回答を生成するAIアシスタントです。回答は必ず提供されたテキストの内容のみから生成し、引用元を明確にしてください。"},
                     {"role": "user", "content": prompt}


### PR DESCRIPTION
## Summary
- allow configuring OpenAI model in `AIQAGenerator`
- add sidebar model selector and pass choice to generator
- document model configuration in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2bb9de488333a9571a335b5a155f