### PR TITLE
Add tests for text extraction and data export

### DIFF
--- a/tests/test_data_exporter.py
+++ b/tests/test_data_exporter.py
@@ -1,0 +1,109 @@
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from qna_generator.data_exporter import (
+    export_to_jsonl,
+    export_to_json,
+    export_to_csv,
+    export_for_rag,
+    export_for_finetuning,
+)
+
+SAMPLE_QA = [
+    {
+        "question": "Q1",
+        "answer": "A1",
+        "category": "cat",
+        "source": "src",
+        "source_info": "info",
+        "temperature": 0.5,
+    }
+]
+
+
+def test_export_to_jsonl(tmp_path):
+    filename = tmp_path / "data.jsonl"
+    returned = export_to_jsonl(SAMPLE_QA, str(filename))
+    assert returned == str(filename)
+    assert filename.exists()
+    with open(filename, encoding="utf-8") as f:
+        lines = [json.loads(line) for line in f]
+    assert lines == SAMPLE_QA
+
+
+def test_export_to_json(tmp_path):
+    filename = tmp_path / "data.json"
+    returned = export_to_json(SAMPLE_QA, str(filename))
+    assert returned == str(filename)
+    assert filename.exists()
+    with open(filename, encoding="utf-8") as f:
+        content = json.load(f)
+    assert content == SAMPLE_QA
+
+
+def test_export_to_csv(tmp_path):
+    filename = tmp_path / "data.csv"
+    returned = export_to_csv(SAMPLE_QA, str(filename))
+    assert returned == str(filename)
+    assert filename.exists()
+    with open(filename, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows == [
+        {
+            "question": "Q1",
+            "answer": "A1",
+            "category": "cat",
+            "source": "src",
+            "source_info": "info",
+            "temperature": "0.5",
+        }
+    ]
+
+
+def test_export_for_rag(tmp_path):
+    filename = tmp_path / "rag.jsonl"
+    returned = export_for_rag(SAMPLE_QA, str(filename))
+    assert returned == str(filename)
+    assert filename.exists()
+    with open(filename, encoding="utf-8") as f:
+        items = [json.loads(line) for line in f]
+    expected = [
+        {
+            "id": "cat_0",
+            "text": "質問: Q1\n回答: A1",
+            "metadata": {
+                "category": "cat",
+                "source": "src",
+                "source_info": "info",
+                "temperature": 0.5,
+            },
+        }
+    ]
+    assert items == expected
+
+
+def test_export_for_finetuning(tmp_path):
+    filename = tmp_path / "finetuning.jsonl"
+    returned = export_for_finetuning(SAMPLE_QA, str(filename))
+    assert returned == str(filename)
+    assert filename.exists()
+    with open(filename, encoding="utf-8") as f:
+        items = [json.loads(line) for line in f]
+    expected = [
+        {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "あなたはcatに関する質問に答えるアシスタントです。",
+                },
+                {"role": "user", "content": "Q1"},
+                {"role": "assistant", "content": "A1"},
+            ]
+        }
+    ]
+    assert items == expected

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -4,11 +4,16 @@ from pathlib import Path
 
 import fitz
 import pytest
+import requests
+from docx import Document
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from qna_generator.data_processor import (
     MAX_UPLOAD_SIZE,
     extract_text_from_uploaded_file,
+    extract_text_from_url,
+    extract_text_from_pdf,
+    extract_text_from_docx,
 )
 
 
@@ -31,6 +36,66 @@ def create_pdf_bytes(text: str) -> bytes:
     page.insert_text((72, 72), text)
     doc.save(buf)
     return buf.getvalue()
+
+
+def create_pdf_file(tmp_path, text: str) -> Path:
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(create_pdf_bytes(text))
+    return pdf_path
+
+
+def create_docx_file(tmp_path, text: str) -> Path:
+    docx_path = tmp_path / "sample.docx"
+    doc = Document()
+    doc.add_paragraph(text)
+    doc.save(docx_path)
+    return docx_path
+
+
+def test_extract_text_from_url_success(monkeypatch):
+    class DummyResponse:
+        text = "<html><body><p>Hello</p></body></html>"
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, timeout, headers):  # pragma: no cover - simple mock
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    text = extract_text_from_url("http://example.com")
+    assert "Hello" in text
+
+
+def test_extract_text_from_url_error(monkeypatch):
+    def mock_get(url, timeout, headers):  # pragma: no cover - simple mock
+        raise requests.exceptions.RequestException("error")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    with pytest.raises(requests.exceptions.RequestException):
+        extract_text_from_url("http://example.com")
+
+
+def test_extract_text_from_pdf(tmp_path):
+    pdf_path = create_pdf_file(tmp_path, "PDF Test")
+    text = extract_text_from_pdf(str(pdf_path))
+    assert "PDF Test" in text
+
+
+def test_extract_text_from_pdf_error():
+    with pytest.raises(RuntimeError):
+        extract_text_from_pdf("missing.pdf")
+
+
+def test_extract_text_from_docx(tmp_path):
+    docx_path = create_docx_file(tmp_path, "DOCX Test")
+    text = extract_text_from_docx(str(docx_path))
+    assert "DOCX Test" in text
+
+
+def test_extract_text_from_docx_error():
+    with pytest.raises(RuntimeError):
+        extract_text_from_docx("missing.docx")
 
 
 def test_extract_text_from_uploaded_pdf():


### PR DESCRIPTION
## Summary
- add extensive tests for text extraction from URL, PDF, and DOCX files
- cover file size limits and error handling in data processing
- ensure all export functions produce expected files and contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f7234f6648333bea23bba6e385472