### PR TITLE
docs: describe export formats and download workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ pip install -r requirements.txt
     ```
 3. A browser window will open. Enter an API key if you didn't set one, choose an OpenAI model in the sidebar (defaults to `gpt-4o-mini`), then provide a URL or upload a PDF/DOCX file to generate Q&A pairs.
 
+## Export formats
+
+After generating Q&A data, the app can export files suitable for different workflows.
+
+**Streamlit UI**
+
+1. In the export section, choose either **RAG用データでダウンロード** or **ファインチューニング用データでダウンロード**.
+2. A new download button appears. Click **RAG用データをダウンロード** or **ファインチューニング用データをダウンロード** to save the generated file.
+
+**Python API**
+
+```python
+from qna_generator.data_exporter import export_for_rag, export_for_finetuning
+
+rag_file = export_for_rag(qa_data)          # -> rag_data_YYYYMMDD_HHMMSS.jsonl
+finetune_file = export_for_finetuning(qa_data)  # -> finetuning_data_YYYYMMDD_HHMMSS.jsonl
+```
+
+Both functions generate [JSON Lines](https://jsonlines.org/) files containing one record per line.
+
 ## Model configuration
 
 The "Settings" sidebar includes a **model** selector. The chosen model is used for both category and Q&A generation.


### PR DESCRIPTION
## Summary
- document RAG and fine-tuning exports in README
- explain UI steps to download generated files and provide Python API examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900093fba0833384a1775fc27f009b