### PR TITLE
Add Windows startup script for Streamlit app

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d "%~dp0"
+streamlit run app.py %*


### PR DESCRIPTION
## Summary
- add `start.bat` to launch the Streamlit app on Windows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68902258e1e88333819b12b22819ea6e